### PR TITLE
Fix case-sensitive lookup in ConverterFactory

### DIFF
--- a/src/main/java/joselusc/libraries/file2file/converters/factory/ConverterFactory.java
+++ b/src/main/java/joselusc/libraries/file2file/converters/factory/ConverterFactory.java
@@ -63,7 +63,9 @@ public class ConverterFactory {
      * @param converterSupplier A supplier function that provides an instance of the converter
      */
     public static void registerConverter(String inputExt, String outputExt, Supplier<Converter> converterSupplier) {
-        converters.computeIfAbsent(inputExt, k -> new HashMap<>()).put(outputExt, converterSupplier);
+        String inKey = inputExt.toLowerCase();
+        String outKey = outputExt.toLowerCase();
+        converters.computeIfAbsent(inKey, k -> new HashMap<>()).put(outKey, converterSupplier);
     }
 
     /**
@@ -76,6 +78,10 @@ public class ConverterFactory {
      */
     public static Converter getConverter(String inputFile, String targetType) throws IllegalArgumentException {
         String extension = getFileExtension(inputFile);
+        if (extension != null) {
+            extension = extension.toLowerCase();
+        }
+        targetType = targetType.toLowerCase();
 
         if (extension == null || !converters.containsKey(extension)) {
             throw new IllegalArgumentException("No available converters for " + inputFile);

--- a/src/test/java/joselusc/libraries/file2file/converters/ConverterFactoryTest.java
+++ b/src/test/java/joselusc/libraries/file2file/converters/ConverterFactoryTest.java
@@ -1,0 +1,24 @@
+package joselusc.libraries.file2file.converters;
+
+import joselusc.libraries.file2file.converters.factory.ConverterFactory;
+import joselusc.libraries.file2file.converters.interfaces.Converter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link ConverterFactory} to ensure case-insensitive lookups.
+ */
+class ConverterFactoryTest {
+
+    @Test
+    void testCaseInsensitiveLookup() {
+        Converter csh = ConverterFactory.getConverter("SCRIPT.CSH", "SH");
+        assertNotNull(csh);
+        assertTrue(csh instanceof Csh2ShConverter);
+
+        Converter enc = ConverterFactory.getConverter("file.Txt", "ENCODING");
+        assertNotNull(enc);
+        assertTrue(enc instanceof EncodingConverter);
+    }
+}


### PR DESCRIPTION
## Summary
- normalize extension and targetType lookup to handle case-insensitive names
- store converters in lower-case keys
- add tests verifying case-insensitive retrieval

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68690e523de88333b3c7e144b4715a91