### PR TITLE
Implement --dry-run and --backup CLI functionalities

### DIFF
--- a/src/main/java/joselusc/libraries/file2file/FileConverter.java
+++ b/src/main/java/joselusc/libraries/file2file/FileConverter.java
@@ -56,6 +56,18 @@ public class FileConverter {
                 .build();
         options.addOption(helpOption);
 
+        Option dryRunOption = Option.builder()
+                .longOpt("dry-run")
+                .desc("Show what would be modified and a diff without writing to disk")
+                .build();
+        options.addOption(dryRunOption);
+
+        Option backupOption = Option.builder()
+                .longOpt("backup")
+                .desc("Create a backup copy (.bak) before overwriting any file")
+                .build();
+        options.addOption(backupOption);
+
         CommandLineParser parser = new DefaultParser();
         HelpFormatter formatter = new HelpFormatter();
         CommandLine cmd = null;
@@ -87,6 +99,13 @@ public class FileConverter {
             Converter converter = ConverterFactory.getConverter(inputFilePath, targetType);
             if (converter == null) {
                 throw new IllegalArgumentException("No converter found for " + inputFilePath + " -> " + targetType);
+            }
+
+            if (cmd.hasOption("dry-run")) {
+                converter.setDryRun(true);
+            }
+            if (cmd.hasOption("backup")) {
+                converter.setBackup(true);
             }
 
             if (remainingArgs.length == 2) {

--- a/src/main/java/joselusc/libraries/file2file/converters/AbstractConverter.java
+++ b/src/main/java/joselusc/libraries/file2file/converters/AbstractConverter.java
@@ -11,6 +11,19 @@ import java.util.stream.Stream;
 
 public abstract class AbstractConverter implements Converter {
 
+    protected boolean dryRun = false;
+    protected boolean backup = false;
+
+    @Override
+    public void setDryRun(boolean dryRun) {
+        this.dryRun = dryRun;
+    }
+
+    @Override
+    public void setBackup(boolean backup) {
+        this.backup = backup;
+    }
+
     /**
      * Provides the target extension (including the dot, e.g., ".sh", ".java").
      */
@@ -57,7 +70,9 @@ public abstract class AbstractConverter implements Converter {
 
         if (Files.isDirectory(source)) {
             if (!Files.exists(target)) {
-                Files.createDirectories(target);
+                if (!dryRun) {
+                    Files.createDirectories(target);
+                }
             } else if (!Files.isDirectory(target)) {
                 throw new IOException("Target exists but is not a directory: " + target);
             }
@@ -81,7 +96,9 @@ public abstract class AbstractConverter implements Converter {
                                 targetFile = targetFile.resolveSibling(fileName);
                             }
 
-                            Files.createDirectories(targetFile.getParent());
+                            if (!dryRun) {
+                                Files.createDirectories(targetFile.getParent());
+                            }
                             convertFile(p, targetFile);
                         }
                     } catch (IOException e) {
@@ -106,7 +123,9 @@ public abstract class AbstractConverter implements Converter {
             } else {
                 // If target is a file path but parent doesn't exist, create it
                 if (targetFile.getParent() != null && !Files.exists(targetFile.getParent())) {
-                    Files.createDirectories(targetFile.getParent());
+                    if (!dryRun) {
+                        Files.createDirectories(targetFile.getParent());
+                    }
                 }
             }
             convertFile(source, targetFile);
@@ -121,7 +140,42 @@ public abstract class AbstractConverter implements Converter {
         // Let subclass modify the content
         String converted = convertContent(content);
 
+        if (dryRun) {
+            System.out.println("--- Dry Run: " + source + " -> " + target + " ---");
+            System.out.println(generateSimpleDiff(content, converted));
+            System.out.println("--------------------------------------------------\n");
+            return;
+        }
+
+        if (backup && Files.exists(target)) {
+            Path backupFile = target.resolveSibling(target.getFileName().toString() + ".bak");
+            Files.copy(target, backupFile, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+            System.out.println("Created backup: " + backupFile);
+        }
+
         Files.write(target, converted.getBytes(charset));
+    }
+
+    private String generateSimpleDiff(String original, String converted) {
+        String[] origLines = original.split("\n", -1);
+        String[] convLines = converted.split("\n", -1);
+        StringBuilder diff = new StringBuilder();
+
+        int i = 0, j = 0;
+        while (i < origLines.length || j < convLines.length) {
+            if (i < origLines.length && j < convLines.length && origLines[i].equals(convLines[j])) {
+                diff.append("  ").append(origLines[i]).append("\n");
+                i++;
+                j++;
+            } else if (i < origLines.length && (j >= convLines.length || !origLines[i].equals(convLines[j]))) {
+                diff.append("- ").append(origLines[i]).append("\n");
+                i++;
+            } else if (j < convLines.length) {
+                diff.append("+ ").append(convLines[j]).append("\n");
+                j++;
+            }
+        }
+        return diff.toString();
     }
 
     protected Charset detectCharset(Path path) throws IOException {

--- a/src/main/java/joselusc/libraries/file2file/converters/interfaces/Converter.java
+++ b/src/main/java/joselusc/libraries/file2file/converters/interfaces/Converter.java
@@ -18,6 +18,23 @@ public interface Converter {
     void convert(Path source, Path target) throws IOException;
 
     /**
+     * Configures the dry-run mode. If true, no files should be modified.
+     * @param dryRun true to enable dry-run mode
+     */
+    default void setDryRun(boolean dryRun) {
+        // Default implementation does nothing
+    }
+
+    /**
+     * Configures the backup mode. If true, existing files should be backed up
+     * before being overwritten.
+     * @param backup true to enable backup mode
+     */
+    default void setBackup(boolean backup) {
+        // Default implementation does nothing
+    }
+
+    /**
      * Converts the specified input file and returns the resulting output file.
      * Legacy method for backward compatibility.
      *


### PR DESCRIPTION
Added two new CLI flags and underlying mechanisms:
1) `--dry-run`: Will calculate the changes and display a basic line-by-line diff comparing original file output and converted strings. No files or directories will be generated.
2) `--backup`: Before writing out new text content, if the target file currently exists, a backup with `.bak` suffix is securely generated with a standard Java NIO copy operation.

---
*PR created automatically by Jules for task [1054365506669506914](https://jules.google.com/task/1054365506669506914) started by @Joselu2099*