### PR TITLE
🧹 Replace System.out/err with Logger in EncodingConverter

### DIFF
--- a/src/main/java/joselusc/libraries/file2file/converters/AbstractConverter.java
+++ b/src/main/java/joselusc/libraries/file2file/converters/AbstractConverter.java
@@ -7,9 +7,13 @@ import java.nio.charset.MalformedInputException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 public abstract class AbstractConverter implements Converter {
+
+    private static final Logger logger = Logger.getLogger(AbstractConverter.class.getName());
 
     /**
      * Provides the target extension (including the dot, e.g., ".sh", ".java").
@@ -85,7 +89,7 @@ public abstract class AbstractConverter implements Converter {
                             convertFile(p, targetFile);
                         }
                     } catch (IOException e) {
-                        System.err.println("Failed to convert file " + p + ": " + e.getMessage());
+                        logger.log(Level.SEVERE, "Failed to convert file " + p + ": " + e.getMessage());
                     }
                 });
             }

--- a/src/main/java/joselusc/libraries/file2file/converters/EncodingConverter.java
+++ b/src/main/java/joselusc/libraries/file2file/converters/EncodingConverter.java
@@ -4,6 +4,8 @@ import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.file.*;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import joselusc.libraries.file2file.converters.interfaces.Converter;
 
@@ -30,6 +32,8 @@ import joselusc.libraries.file2file.converters.interfaces.Converter;
  * </p>
  */
 public class EncodingConverter extends AbstractConverter {
+
+    private static final Logger logger = Logger.getLogger(EncodingConverter.class.getName());
 
     private static final List<String> DEFAULT_EXTENSIONS = Arrays.asList(
         ".java", ".js", ".jsp", ".xhtml", ".html", ".sql"
@@ -157,15 +161,15 @@ public class EncodingConverter extends AbstractConverter {
             sourceEncoding = Charset.forName(args[1]);
             targetEncoding = Charset.forName(args[2]);
         } catch (Exception e) {
-            System.out.println("Unsupported encoding: " + e.getMessage());
+            logger.log(Level.SEVERE, "Unsupported encoding: " + e.getMessage());
             return;
         }
 
         try {
             convertDirectory(root, sourceEncoding, targetEncoding, extensions, backup, silent);
-            if (!silent) System.out.println("Conversion finished.");
+            if (!silent) logger.info("Conversion finished.");
         } catch (Exception e) {
-            System.err.println("Error: " + e.getMessage());
+            logger.log(Level.SEVERE, "Error: " + e.getMessage());
         }
     }
 
@@ -249,9 +253,9 @@ public class EncodingConverter extends AbstractConverter {
             try (OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(file, false), targetEncoding)) {
                 writer.write(content);
             }
-            if (!silent) System.out.println("Converted: " + file.getPath());
+            if (!silent) logger.info("Converted: " + file.getPath());
         } catch (IOException e) {
-            System.err.println("Error: " + file.getPath() + " → " + e.getMessage());
+            logger.log(Level.SEVERE, "Error: " + file.getPath() + " → " + e.getMessage());
         }
     }
 }


### PR DESCRIPTION
### 🎯 What:
Replaced `System.out.println` and `System.err.println` with `java.util.logging.Logger` in `EncodingConverter.java` and `AbstractConverter.java`.

### 💡 Why:
Using a standard logging framework instead of printing directly to console improves maintainability, allows for better control over log levels, and is consistent with professional Java development practices.

### ✅ Verification:
- Compiled the affected classes and their dependencies using `javac` to ensure no syntax errors were introduced.
- Verified that "silent mode" logic is preserved (logs are still guarded by `if (!silent)` where applicable).
- Standard CLI help messages continue to use `System.out`.

### ✨ Result:
The codebase now uses standard Java logging for progress and error reporting in the encoding conversion modules, making the code cleaner and more robust.

---
*PR created automatically by Jules for task [1121859972751786506](https://jules.google.com/task/1121859972751786506) started by @Joselu2099*