### PR TITLE
🔒 [security fix] Fix command injection in Csh2ShConverter goto handling

### DIFF
--- a/src/main/java/joselusc/libraries/file2file/converters/Csh2ShConverter.java
+++ b/src/main/java/joselusc/libraries/file2file/converters/Csh2ShConverter.java
@@ -372,8 +372,8 @@ public class Csh2ShConverter extends AbstractConverter {
             // In Bash, goto is not supported. We can call the function if label exists.
             if (label.matches("^[A-Za-z_][A-Za-z0-9_]*$")) {
                 return label + "  # goto replaced by function call\nreturn";
-            } else if (label.startsWith("$")) {
-                return "eval \"" + label + "\"\nreturn";
+            } else if (label.matches("^\\$([A-Za-z_][A-Za-z0-9_]*|[0-9]+|\\{[A-Za-z_][A-Za-z0-9_]*\\}|\\{[0-9]+\\})$")) {
+                return "\"" + label + "\"\nreturn";
             } else {
                 return "# goto " + label + " (not supported in Bash)";
             }

--- a/src/test/java/joselusc/libraries/file2file/converters/Csh2ShConverterTest.java
+++ b/src/test/java/joselusc/libraries/file2file/converters/Csh2ShConverterTest.java
@@ -157,7 +157,7 @@ class Csh2ShConverterTest {
 
         assertTrue(shContent.contains("label1() {"));
         assertTrue(shContent.contains("label1"));
-        assertTrue(shContent.contains("eval \"$next\""));
+        assertTrue(shContent.contains("\"$next\""));
         assertTrue(shContent.contains("return"));
     }
 
@@ -216,6 +216,42 @@ class Csh2ShConverterTest {
 
         assertTrue(shContent.contains("export VAR1=value1"));
         assertTrue(shContent.contains("VAR2=value2"));
+    }
+
+    /**
+     * Tests that malicious goto labels are handled safely.
+     */
+    @Test
+    void testGotoSecurity() throws IOException {
+        String cshScript = "goto \$(rm -rf /)\ngoto \"; echo injected; #";
+        Path cshFile = tempDir.resolve("security.csh");
+        Files.write(cshFile, cshScript.getBytes());
+
+        File shFile = Csh2ShConverter.getInstance().convert(cshFile.toString());
+        String shContent = new String(Files.readAllBytes(shFile.toPath()));
+
+        // Should not contain eval
+        assertFalse(shContent.contains("eval"));
+        // Should be commented out as unsupported
+        assertTrue(shContent.contains("# goto $(rm -rf /) (not supported in Bash)"));
+        assertTrue(shContent.contains("# goto \"; echo injected; # (not supported in Bash)"));
+    }
+
+    /**
+     * Tests that valid variable goto labels are converted safely.
+     */
+    @Test
+    void testGotoVariableSafe() throws IOException {
+        String cshScript = "goto \$VAR\ngoto \${VAR2}";
+        Path cshFile = tempDir.resolve("safe_vars.csh");
+        Files.write(cshFile, cshScript.getBytes());
+
+        File shFile = Csh2ShConverter.getInstance().convert(cshFile.toString());
+        String shContent = new String(Files.readAllBytes(shFile.toPath()));
+
+        assertTrue(shContent.contains("\"\$VAR\""));
+        assertTrue(shContent.contains("\"\${VAR2}\""));
+        assertFalse(shContent.contains("eval"));
     }
 
     /**


### PR DESCRIPTION
🎯 **What:** Fixed a command injection vulnerability in the Csh2ShConverter class where labels starting with '$' in goto statements were unsafely passed to 'eval' in the generated Bash script.

⚠️ **Risk:** An attacker could provide a malicious label like '$(rm -rf /)' or '; echo injected; #', leading to arbitrary code execution when the converted Bash script is run.

🛡️ **Solution:** 
1. Replaced 'eval "$label"' with '"$label"' in the generated Bash script. In Bash, calling a quoted variable that contains a function name is safe and achieves the intended dynamic dispatch.
2. Implemented strict regex validation for labels starting with '$' to ensure they only contain valid variable characters or positional parameters.
3. Added security-focused unit tests to verify that malicious labels are safely handled and valid variable labels continue to work as expected.

---
*PR created automatically by Jules for task [10712692335054061371](https://jules.google.com/task/10712692335054061371) started by @Joselu2099*