### PR TITLE
🧪 Add error tests for ConverterFactory unknown extension

### DIFF
--- a/src/test/java/joselusc/libraries/file2file/converters/factory/ConverterFactoryTest.java
+++ b/src/test/java/joselusc/libraries/file2file/converters/factory/ConverterFactoryTest.java
@@ -1,0 +1,38 @@
+package joselusc.libraries.file2file.converters.factory;
+
+import joselusc.libraries.file2file.converters.interfaces.Converter;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConverterFactoryTest {
+
+    @Test
+    void testGetConverterSuccess() {
+        Converter converter = ConverterFactory.getConverter("test.csh", "sh");
+        assertNotNull(converter);
+    }
+
+    @Test
+    void testGetConverterUnknownExtension() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            ConverterFactory.getConverter("test.unknown", "sh");
+        });
+        assertTrue(exception.getMessage().contains("No available converters for test.unknown"));
+    }
+
+    @Test
+    void testGetConverterNoExtension() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            ConverterFactory.getConverter("testfile", "sh");
+        });
+        assertTrue(exception.getMessage().contains("No available converters for testfile"));
+    }
+
+    @Test
+    void testGetConverterUnknownTargetType() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            ConverterFactory.getConverter("test.csh", "unknown");
+        });
+        assertTrue(exception.getMessage().contains("No conversion from csh to unknown"));
+    }
+}


### PR DESCRIPTION
This PR adds a new test class `ConverterFactoryTest` to improve the test coverage for `ConverterFactory.getConverter`. It specifically addresses the missing error test for unknown file extensions and adds coverage for other edge cases such as missing extensions and unknown target types.

🎯 **What:** The testing gap for error handling in `ConverterFactory.getConverter`.
📊 **Coverage:**
- Happy path (successful converter retrieval)
- Unknown file extensions
- Files without extensions
- Unknown target types
✨ **Result:** Improved reliability and confidence in the factory's error handling.

---
*PR created automatically by Jules for task [16408233250251506305](https://jules.google.com/task/16408233250251506305) started by @Joselu2099*