### PR TITLE
🧹 [Code Health] Remove unused Logger imports in EncodingConverter.java

### DIFF
--- a/src/main/java/joselusc/libraries/file2file/converters/EncodingConverter.java
+++ b/src/main/java/joselusc/libraries/file2file/converters/EncodingConverter.java
@@ -4,8 +4,6 @@ import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.file.*;
 import java.util.*;
-import java.util.logging.Logger;
-import java.util.logging.Level;
 
 import joselusc.libraries.file2file.converters.interfaces.Converter;
 


### PR DESCRIPTION
🎯 **Qué:** Se eliminaron las importaciones sin usar de `java.util.logging.Logger` y `java.util.logging.Level` en `EncodingConverter.java`.
💡 **Por qué:** Las importaciones no se usaban en este archivo porque la instancia `LOGGER` se hereda de `AbstractConverter`. Esta limpieza simple y libre de riesgos mejora la legibilidad y el mantenimiento del código.
✅ **Verificación:** Se validó que el código compile correctamente y se ejecutaron todos los tests unitarios (`mvn test`) para asegurar que no hubiese regresiones. Todos pasaron sin problemas.
✨ **Resultado:** Código más limpio y sin dependencias no utilizadas, sin ningún impacto en la funcionalidad de la aplicación.

---
*PR created automatically by Jules for task [12228786622910375007](https://jules.google.com/task/12228786622910375007) started by @Joselu2099*