### PR TITLE
🧹 remove unused imports in AbstractConverter

### DIFF
--- a/src/main/java/joselusc/libraries/file2file/converters/AbstractConverter.java
+++ b/src/main/java/joselusc/libraries/file2file/converters/AbstractConverter.java
@@ -11,9 +11,6 @@ import java.util.stream.Stream;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 import java.nio.file.FileSystems;
-import java.nio.file.FileVisitResult;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was removing unused imports (`SimpleFileVisitor`, `FileVisitResult`, `BasicFileAttributes`) in `AbstractConverter.java`.
💡 **Why:** How this improves maintainability: It reduces clutter in the class, cleaning up remnants of previous file traversal logic that is no longer needed after switching to `Files.walk()`.
✅ **Verification:** I confirmed the change is safe by building the project with `mvn clean compile` and running the test suite with `mvn clean test`. Both completed successfully.
✨ **Result:** The codebase is cleaner and doesn't load unneeded classes.

---
*PR created automatically by Jules for task [15065986862715130257](https://jules.google.com/task/15065986862715130257) started by @Joselu2099*