### PR TITLE
🧪 Add test for missing source path in AbstractConverter

### DIFF
--- a/src/test/java/joselusc/libraries/file2file/converters/AbstractConverterTest.java
+++ b/src/test/java/joselusc/libraries/file2file/converters/AbstractConverterTest.java
@@ -1,0 +1,40 @@
+package joselusc.libraries.file2file.converters;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AbstractConverterTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void testConvertThrowsIOExceptionWhenSourceDoesNotExist() {
+        Path source = tempDir.resolve("non_existent_file.txt");
+        Path target = tempDir.resolve("target.txt");
+
+        AbstractConverter converter = new AbstractConverter() {
+            @Override
+            protected String getTargetExtension() {
+                return ".txt";
+            }
+
+            @Override
+            protected boolean acceptFile(Path file) {
+                return true;
+            }
+        };
+
+        IOException exception = assertThrows(IOException.class, () -> {
+            converter.convert(source, target);
+        });
+
+        assertEquals("Source path does not exist: " + source, exception.getMessage());
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was an unhandled path creation edge case in `AbstractConverter.convert` where a non-existent source path lacked test coverage.

📊 **Coverage:** The scenario where the `source` path passed to `convert` does not exist is now tested using a temporary directory path.

✨ **Result:** Test coverage improved and the edge case is robustly verified to throw an `IOException` as expected.

---
*PR created automatically by Jules for task [11374692334243078983](https://jules.google.com/task/11374692334243078983) started by @Joselu2099*