### PR TITLE
🔒 Log full exception stacktraces during conversion errors

### DIFF
--- a/src/main/java/joselusc/libraries/file2file/FileConverter.java
+++ b/src/main/java/joselusc/libraries/file2file/FileConverter.java
@@ -2,6 +2,8 @@ package joselusc.libraries.file2file;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.apache.commons.cli.*;
 
 import joselusc.libraries.file2file.converters.interfaces.Converter;
@@ -35,6 +37,8 @@ import joselusc.libraries.file2file.converters.factory.ConverterFactory;
  * @author Jose Luis Sanchez Carrasco
  */
 public class FileConverter {
+
+    private static final Logger LOGGER = Logger.getLogger(FileConverter.class.getName());
 
     /**
      * Entry point for the file2file command-line application.
@@ -130,6 +134,7 @@ public class FileConverter {
                 System.out.println("Conversion successful: " + outputFile.getAbsolutePath());
             }
         } catch (IllegalArgumentException | IOException e) {
+            LOGGER.log(Level.SEVERE, "Error during conversion", e);
             System.err.println("Error: " + e.getMessage());
             System.exit(1);
         }

--- a/src/main/java/joselusc/libraries/file2file/converters/AbstractConverter.java
+++ b/src/main/java/joselusc/libraries/file2file/converters/AbstractConverter.java
@@ -135,7 +135,7 @@ public abstract class AbstractConverter implements Converter {
                             convertFile(p, targetFile);
                         }
                     } catch (IOException e) {
-                        System.err.println("Failed to convert file " + p + ": " + e.getMessage());
+                        LOGGER.log(Level.SEVERE, "Failed to convert file " + p, e);
                     }
                 });
             }

--- a/src/main/java/joselusc/libraries/file2file/converters/EncodingConverter.java
+++ b/src/main/java/joselusc/libraries/file2file/converters/EncodingConverter.java
@@ -167,7 +167,7 @@ public class EncodingConverter extends AbstractConverter {
             convertDirectory(root, sourceEncoding, targetEncoding, extensions, backup, silent);
             if (!silent) System.out.println("Conversion finished.");
         } catch (Exception e) {
-            LOGGER.severe("Error: " + e.getMessage());
+            LOGGER.log(Level.SEVERE, "Error during directory conversion", e);
         }
     }
 
@@ -253,7 +253,7 @@ public class EncodingConverter extends AbstractConverter {
             }
             if (!silent) System.out.println("Converted: " + file.getPath());
         } catch (IOException e) {
-            LOGGER.severe("Error: " + file.getPath() + " 2192 " + e.getMessage());
+            LOGGER.log(Level.SEVERE, "Error converting file: " + file.getPath(), e);
         }
     }
 }

--- a/src/main/java/joselusc/libraries/file2file/gui/File2FileGUI.java
+++ b/src/main/java/joselusc/libraries/file2file/gui/File2FileGUI.java
@@ -13,11 +13,15 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.text.SimpleDateFormat;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.*;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class File2FileGUI extends JFrame {
+
+    private static final Logger LOGGER = Logger.getLogger(File2FileGUI.class.getName());
 
     private JTextField fileField;
     private JComboBox<String> converterCombo;
@@ -176,6 +180,7 @@ public class File2FileGUI extends JFrame {
                 JOptionPane.showMessageDialog(this, "Conversion done, but could not rename the file.", "Warning", JOptionPane.WARNING_MESSAGE);
             }
         } catch (Exception ex) {
+            LOGGER.log(Level.SEVERE, "Error during conversion", ex);
             JOptionPane.showMessageDialog(this, "Error: " + ex.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
         }
     }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the suppression of exception stacktraces during file conversion errors. Previously, only the short error message was logged or displayed, which made diagnosing failures and security auditing difficult.

⚠️ **Risk:** If left unfixed, system administrators and developers would lack the necessary context to troubleshoot conversion failures or investigate potential exploitation attempts that trigger exceptions. Swallowing stacktraces is a poor security practice as it hides the root cause of errors.

🛡️ **Solution:** The fix introduces the use of `java.util.logging.Logger` across the primary conversion entry points (GUI, CLI, and base converter classes). By passing the exception object to `LOGGER.log(Level.SEVERE, ..., exception)`, the full stacktrace is now preserved in the application logs, while maintaining a user-friendly message in the GUI.

---
*PR created automatically by Jules for task [7683759256786910964](https://jules.google.com/task/7683759256786910964) started by @Joselu2099*