### PR TITLE
🔒 Fix command injection vulnerability in generate_report.py

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -2,14 +2,16 @@ import subprocess
 import re
 
 def run_cmd(cmd):
-    return subprocess.check_output(cmd, shell=True).decode('utf-8')
+    return subprocess.check_output(cmd).decode('utf-8')
 
-log = run_cmd('git log --since="midnight" --oneline')
+log = run_cmd(['git', 'log', '--since=midnight', '--oneline'])
 commits = log.strip().split('\n')
 for c in commits:
+    if not c: continue
     parts = c.split(' ', 1)
     if len(parts) < 2: continue
     hash = parts[0]
     msg = parts[1]
-    stat = run_cmd(f'git show {hash} --stat | tail -n 1')
+    stat_out = run_cmd(['git', 'show', hash, '--stat'])
+    stat = stat_out.strip().split('\n')[-1]
     print(f"- {hash}: {msg} ({stat.strip()})")

--- a/test_generate_report.py
+++ b/test_generate_report.py
@@ -1,0 +1,24 @@
+import unittest
+import subprocess
+from generate_report import run_cmd
+
+class TestGenerateReport(unittest.TestCase):
+    def test_run_cmd_safe(self):
+        # A simple, safe command
+        output = run_cmd(['echo', 'hello'])
+        self.assertEqual(output.strip(), 'hello')
+
+    def test_run_cmd_injection_prevented(self):
+        # An attempt to inject commands that should fail or be treated as literals
+        # When shell=False, subprocess treats the list elements as arguments to the first element
+        # It won't execute `; echo injected` as a separate command
+        output = run_cmd(['echo', 'hello;', 'echo', 'injected'])
+        self.assertEqual(output.strip(), 'hello; echo injected')
+
+    def test_run_cmd_invalid_command(self):
+        # When shell=False, checking that an invalid command raises FileNotFoundError
+        with self.assertRaises(FileNotFoundError):
+            run_cmd(['not_a_real_command', 'test'])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** There was a command injection vulnerability in `generate_report.py` due to the use of `subprocess.check_output` with `shell=True` and string interpolation, particularly when handling external input like git history which could potentially be manipulated.
⚠️ **Risk:** An attacker could potentially execute arbitrary shell commands if they are able to inject malicious content (e.g., using `;`) into the git log messages or branch names, which would then be executed by the script.
🛡️ **Solution:** The vulnerability was resolved by removing `shell=True` from the `subprocess.check_output` call and modifying the script to pass arguments as lists. Shell-specific features like pipelines (`| tail -n 1`) were replaced with safe Python-native string manipulation (e.g., `split('\n')[-1]`). Tests were also added to validate that the function prevents injections and treats them as literal string arguments.

---
*PR created automatically by Jules for task [3797081561304364304](https://jules.google.com/task/3797081561304364304) started by @Joselu2099*